### PR TITLE
Update mapper to use countryless locales

### DIFF
--- a/lib/mapper.js
+++ b/lib/mapper.js
@@ -123,6 +123,7 @@ function locale(facade){
  */
 
 function properties(properties){
+  del(properties, 'country');
   del(properties, 'language');
   del(properties, 'revenue');
   del(properties, 'event_id');

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "devDependencies": {
     "istanbul": "0.x",
     "jscs": "1.x",
-    "locale-string": "^1.0.0",
+    "locale-string": "1.1.0",
     "merge-util": "^0.1.0",
     "mocha": "2.x",
     "ms": "0.x",

--- a/test/fixtures/page-full.json
+++ b/test/fixtures/page-full.json
@@ -6,6 +6,7 @@
     "name": "Analytics iOS",
     "category": "Docs",
     "properties": {
+      "country": "United States",
       "revenue": 19.99,
       "property": true
     },
@@ -16,6 +17,7 @@
         "brand": "device-brand",
         "manufacturer": "device-manufacturer"
       },
+      "locale": "en",
       "library": { "name": "analytics-ios" },
       "app": { "version": "app-version" },
       "os": {
@@ -50,6 +52,8 @@
     "device_id": "device-id",
     "device_manufacturer": "device-manufacturer",
     "ip": "0.0.0.0",
+    "language": "English",
+    "country": "United States",
     "location_lat": "latitude",
     "location_lng": "longitude",
     "device_model": "device-model",

--- a/test/fixtures/screen-full.json
+++ b/test/fixtures/screen-full.json
@@ -6,6 +6,7 @@
     "name": "Analytics iOS",
     "category": "Docs",
     "properties": {
+      "country": "United States",
       "revenue": 19.99,
       "property": true
     },
@@ -16,6 +17,7 @@
         "brand": "device-brand",
         "manufacturer": "device-manufacturer"
       },
+      "locale": "en",
       "library": { "name": "analytics-ios" },
       "app": { "version": "app-version" },
       "os": {
@@ -50,6 +52,8 @@
     "device_id": "device-id",
     "device_manufacturer": "device-manufacturer",
     "ip": "0.0.0.0",
+    "language": "English",
+    "country": "United States",
     "location_lat": "latitude",
     "location_lng": "longitude",
     "device_model": "device-model",

--- a/test/fixtures/track-full.json
+++ b/test/fixtures/track-full.json
@@ -5,6 +5,7 @@
     "event": "my-event",
     "timestamp": "2014",
     "properties": {
+      "country": "United States",
       "revenue": 19.99,
       "property": true
     },
@@ -15,6 +16,7 @@
         "brand": "device-brand",
         "manufacturer": "device-manufacturer"
       },
+      "locale": "en",
       "library": { "name": "analytics-ios" },
       "app": { "version": "app-version" },
       "os": {
@@ -49,6 +51,8 @@
     "device_id": "device-id",
     "device_manufacturer": "device-manufacturer",
     "ip": "0.0.0.0",
+    "language": "English",
+    "country": "United States",
     "location_lat": 1.0,
     "location_lng": 1.0,
     "device_model": "device-model",


### PR DESCRIPTION
Previously users could only send locales with a country (e.g. `en-US`); this lets users send countryless locales (`en`). It also remaps `country` from being a custom property (which looks to have been a mistake) and instead sends them as `country`, which is what Amplitude expects.

This also means we no longer send `country` as a custom property to Amplitude.
