### PR TITLE
update platform value

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -63,7 +63,7 @@ function identify(payload, fn) {
     .type('json')
     .query({ api_key: this.settings.apiKey })
     .query({ identification: JSON.stringify(payload) })
-    .end(this.handle(function(err, res) {
+    .end(this.handle(function(err, res){
       if (err) return fn(err, res);
       if ('invalid api_key' == res.text) return fn(self.error('invalid api_key'));
       fn(null, res);

--- a/lib/mapper.js
+++ b/lib/mapper.js
@@ -88,7 +88,6 @@ function common(facade){
     time: facade.timestamp().getTime(),
     library: 'segment',
     app_version: facade.proxy('context.app.version'),
-    platform: facade.proxy('context.library.name'),
     os_name: os,
     os_version: facade.proxy('context.os.version'),
     carrier: facade.proxy('context.network.carrier'),
@@ -118,15 +117,51 @@ function common(facade){
   } else if (os && os.toLowerCase() == 'android') {
       //Older segment clients sent idfa, newer ones send advertisingId
       ret.adid = facade.proxy('device.idfa');
-      if(!ret.adid) {
+      if (!ret.adid) {
         ret.adid = facade.proxy('device.advertisingId');
       }
   }
+
+  var lib = facade.proxy('context.library.name');
+  var platform = platformFromLibrary(lib) || facade.proxy('context.device.type') || (os && os.toLowerCase()) || lib;
+  ret.platform = sanitizePlatform(platform);
 
   ret.user_properties = traits(facade.traits());
 
   return reject(ret);
 }
+
+/**
+ * Maps known Segment libraries to platforms
+ *
+ * @param {String} library
+ * @return {String} platform
+ */
+function platformFromLibrary(library){
+  if (library) {
+    library = library.toLowerCase();
+    if (library == 'analytics.js') return 'Web';
+    if (library == 'analytics-android') return 'Android';
+    if (library == 'analytics-ios') return 'iOS';
+  }
+  return null;
+}
+
+/**
+ * Sanitizies platform values to match Amplitude's format
+ *
+ * @param {String} platform
+ * @return {String} formatted platform value
+ */
+ function sanitizePlatform(platform){
+  if (platform) {
+    platform = platform.toLowerCase();
+    if (platform == 'web') return 'Web';
+    if (platform == 'android') return 'Android';
+    if (platform == 'ios') return 'iOS';
+  }
+  return platform;
+ }
 
 /**
  * Gets the locale object info from the facade

--- a/test/fixtures/identify-full.json
+++ b/test/fixtures/identify-full.json
@@ -40,7 +40,7 @@
   },
   "output": {
     "app_version": "app-version",
-    "platform": "analytics-ios",
+    "platform": "iOS",
     "os_name": "os-name",
     "os_version": "os-version",
     "device_brand": "device-brand",

--- a/test/fixtures/page-full.json
+++ b/test/fixtures/page-full.json
@@ -44,7 +44,7 @@
     "session_id": "session-id",
     "event_id": "event-id",
     "app_version": "app-version",
-    "platform": "analytics-ios",
+    "platform": "iOS",
     "os_name": "os-name",
     "os_version": "os-version",
     "device_brand": "device-brand",

--- a/test/fixtures/screen-full.json
+++ b/test/fixtures/screen-full.json
@@ -44,7 +44,7 @@
     "session_id": "session-id",
     "event_id": "event-id",
     "app_version": "app-version",
-    "platform": "analytics-ios",
+    "platform": "iOS",
     "os_name": "os-name",
     "os_version": "os-version",
     "device_brand": "device-brand",

--- a/test/fixtures/track-android.json
+++ b/test/fixtures/track-android.json
@@ -18,7 +18,7 @@
         "idfa": "device-idfa"
       },
       "locale": "en-US",
-      "library": { "name": "analytics-ios" },
+      "library": { "name": "analytics-android" },
       "app": { "version": "app-version" },
       "os": {
         "name": "Android",
@@ -44,7 +44,7 @@
     "session_id": 1,
     "event_id": 1,
     "app_version": "app-version",
-    "platform": "analytics-ios",
+    "platform": "Android",
     "os_name": "Android",
     "os_version": "os-version",
     "device_brand": "device-brand",

--- a/test/fixtures/track-full.json
+++ b/test/fixtures/track-full.json
@@ -17,7 +17,7 @@
         "manufacturer": "device-manufacturer"
       },
       "locale": "en-US",
-      "library": { "name": "analytics-ios" },
+      "library": { "name": "analytics.js" },
       "app": { "version": "app-version" },
       "os": {
         "name": "os-name",
@@ -43,7 +43,7 @@
     "session_id": 1,
     "event_id": 1,
     "app_version": "app-version",
-    "platform": "analytics-ios",
+    "platform": "Web",
     "os_name": "os-name",
     "os_version": "os-version",
     "device_brand": "device-brand",

--- a/test/fixtures/track-ios.json
+++ b/test/fixtures/track-ios.json
@@ -44,7 +44,7 @@
     "session_id": 1,
     "event_id": 1,
     "app_version": "app-version",
-    "platform": "analytics-ios",
+    "platform": "iOS",
     "os_name": "iOS",
     "os_version": "os-version",
     "device_brand": "device-brand",

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -86,40 +86,40 @@ exports.transaction = function(options){
  * @return {Track}
  */
 
-exports.track = function (options) {
+exports.track = function(options){
   options = options || {};
   return new facade.Track(merge({
-    userId     : firstId,
-    event      : 'Baked a cake',
-    properties : {
-      layers  : ['chocolate', 'strawberry', 'fudge'],
-      revenue : 19.95,
-      numLayers : 10,
-      fat : 0.02,
-      bacon : '1',
-      date : (new Date()).toISOString(),
-      address : {
-        state : 'CA',
-        zip  : 94107,
-        city : 'San Francisco'
+    userId: firstId,
+    event: 'Baked a cake',
+    properties: {
+      layers: ['chocolate', 'strawberry', 'fudge'],
+      revenue: 19.95,
+      numLayers: 10,
+      fat: 0.02,
+      bacon: '1',
+      date: (new Date()).toISOString(),
+      address: {
+        state: 'CA',
+        zip: 94107,
+        city: 'San Francisco'
       }
     },
-    channel    : 'server',
-    timestamp  : new Date(),
-    options : {
-      traits : {
-        email   : options.email || email,
-        age     : 23,
-        created : new Date(),
-        bad     : null,
-        alsoBad : undefined,
-        address : {
-          state : 'CA',
-          zip  : 94107,
-          city : 'San Francisco'
+    channel: 'server',
+    timestamp: new Date(),
+    options: {
+      traits: {
+        email: options.email || email,
+        age: 23,
+        created: new Date(),
+        bad: null,
+        alsoBad: undefined,
+        address: {
+          state: 'CA',
+          zip: 94107,
+          city: 'San Francisco'
         }
       },
-      ip : '4.184.68.0',
+      ip: '4.184.68.0',
       userAgent: 'Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Trident/6.0)'
     }
   }, options));
@@ -132,12 +132,11 @@ exports.track = function (options) {
  * @return {Track}
  */
 
-
-exports.track.bare = function (options) {
+exports.track.bare = function(options){
   return new facade.Track(merge({
-    userId  : 'aaa',
-    event   : 'Bear tracks',
-    channel : 'server'
+    userId: 'aaa',
+    event: 'Bear tracks',
+    channel: 'server'
   }, options || {}));
 };
 
@@ -148,36 +147,36 @@ exports.track.bare = function (options) {
  * @return {Identify}
  */
 
-exports.identify = function (options) {
+exports.identify = function(options){
   options = options || {};
   return new facade.Identify(merge({
-    userId : firstId,
-    traits : {
-      fat         : 0.02,
-      firstName   : 'John',
-      'Last Name' : 'Doe',
-      email       : options.email || email,
-      company     : 'Segment.io',
-      city        : 'San Francisco',
-      state       : 'CA',
-      phone       : '5555555555',
-      websites    : [
+    userId: firstId,
+    traits: {
+      fat: 0.02,
+      firstName: 'John',
+      'Last Name': 'Doe',
+      email: options.email || email,
+      company: 'Segment.io',
+      city: 'San Francisco',
+      state: 'CA',
+      phone: '5555555555',
+      websites: [
         'http://calv.info',
         'http://ianstormtaylor.com',
         'http://ivolo.me',
         'http://rein.pk'
       ],
-      bad     : null,
-      alsoBad : undefined,
-      met : (new Date()).toISOString(),
-      created : new Date('1/12/2013'),
+      bad: null,
+      alsoBad: undefined,
+      met: (new Date()).toISOString(),
+      created: new Date('1/12/2013'),
       userAgent: 'Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Trident/6.0)'
     },
-    context : {
-      ip : '12.212.12.49'
+    context: {
+      ip: '12.212.12.49'
     },
-    timestamp : new Date(),
-    channel : 'server'
+    timestamp: new Date(),
+    channel: 'server'
   }, options));
 };
 
@@ -262,11 +261,11 @@ exports.group = function(options){
  * @return {Alias}
  */
 
-exports.alias = function (options) {
+exports.alias = function(options){
   return new facade.Alias(merge({
-    from      : firstId,
-    to        : secondId,
-    channel   : 'server',
-    timestamp : new Date()
+    from: firstId,
+    to: secondId,
+    channel:'server',
+    timestamp: new Date()
   }, options || {}));
 };

--- a/test/index.js
+++ b/test/index.js
@@ -5,7 +5,7 @@ var mapper = require('../lib/mapper');
 var assert = require('assert');
 var Amplitude = require('..');
 
-describe('Amplitude', function() {
+describe('Amplitude', function(){
   var amplitude;
   var settings;
   var test;
@@ -23,7 +23,7 @@ describe('Amplitude', function() {
       .ensure('settings.apiKey');
   });
 
-  describe('.validate()', function() {
+  describe('.validate()', function(){
     it('should not be valid without an api key', function(){
       test.invalid({}, {});
     });
@@ -83,8 +83,8 @@ describe('Amplitude', function() {
     });
   });
 
-  describe('.page()', function() {
-    it('should map page calls correctly', function(done) {
+  describe('.page()', function(){
+    it('should map page calls correctly', function(done){
       var json = test.fixture('page-basic');
       test
         .set(settings)
@@ -118,7 +118,7 @@ describe('Amplitude', function() {
         .expects(200, done);
     });
 
-    it('should be able to process screen calls with bad fields', function(done) {
+    it('should be able to process screen calls with bad fields', function(done){
       amplitude.screen(helpers.screen(), done);
     });
 
@@ -131,7 +131,7 @@ describe('Amplitude', function() {
     });
   });
 
-  describe('.track()', function() {
+  describe('.track()', function(){
     it('should map track calls correctly', function(done){
       var json = test.fixture('track-basic');
       test
@@ -191,7 +191,7 @@ describe('Amplitude', function() {
     });
   });
 
-  describe('.identify()', function() {
+  describe('.identify()', function(){
     it('should map identify calls correctly', function(done){
       var json = test.fixture('identify-basic');
       test


### PR DESCRIPTION
This PR addresses https://github.com/segmentio/integration-amplitude/issues/9. Sometimes we will see events with platform = 'analytics-ruby', or 'analytics-php', and we expect values like 'iOS', 'Web', or 'Android'. Following suggestions from @f2prateek, we map the segment library to a platform, or fallback on the device / os. Also sometimes Segment's values are all lowercase (like device type), so I added another layer of sanitization to format the values.