### PR TITLE
Regenerate device ID on some versions.

### DIFF
--- a/lib/mapper.js
+++ b/lib/mapper.js
@@ -72,6 +72,17 @@ exports.identify = function(identify){
   return payload;
 };
 
+function deviceId(facade) {
+  var version = facade.proxy('context.library.version');
+  var name = facade.proxy('context.library.name');
+
+  if (name === 'analytics-android' && version  === '1.4.4') {
+    return facade.userId() + ":" + facade.proxy('context.device.model') + ":" + facade.proxy('context.device.id');
+  }
+
+  return facade.proxy('context.device.id') || facade.anonymousId();
+}
+
 /**
  * Format the amplitude specific properties.
  *
@@ -84,7 +95,7 @@ function common(facade){
   var os = facade.proxy('context.os.name');
   var ret = {
     user_id: facade.userId(),
-    device_id: facade.proxy('context.device.id') || facade.anonymousId(),
+    device_id: deviceId(facade),
     time: facade.timestamp().getTime(),
     library: 'segment',
     app_version: facade.proxy('context.app.version'),


### PR DESCRIPTION
Amplitude is using device ID (instead of user ID) for this scenario:

"The problem is that as part of our
data processing pipeline, we do a bunch of processing of the data to
ensure that the data is "clean" (deduplication, time correction, etc.).
In order to support this, we have designed our platform that all events
from the same device id (which we assume are unique to a specific
device) go to the same event processor.  In this case, where lots of
devices are going to the same event processor, it looks to our platform
like an error and/or attack.  So that device id gets throttled, and the
blocked, and we stop accepting events from it."

in version 1.4.4 of the android library - we weren't sending device id
correctly (we send build id which is *NOT* unique for a phone —
https://github.com/segmentio/analytics-android/blob/d33108eabc0a4132966b7a4b713c3686a482ff9d/core/src/main/java/com/segment/android/info/Device.java#L42).

So we generate a pseudo randomish id on the server and send that to
Amplitude.